### PR TITLE
Fix a nil pointer dereference panic in logtail.go

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -20,7 +20,7 @@ type replace struct {
 	str      string
 	repl     []byte
 	matcher  *pcre.Regexp
-	replacer *replacer.Replacer
+	replacer replacer.Replacer
 }
 
 type match_or_default struct {


### PR DESCRIPTION
Hey! LMC, still going strong :)
This seems to have fixed a sporadic crash we were seeing.