### PR TITLE
Init script: Avoid leaking FD when starting logmetrics_collector

### DIFF
--- a/utils/etc/init.d/logmetrics_collector
+++ b/utils/etc/init.d/logmetrics_collector
@@ -63,6 +63,9 @@ start() {
   #Perl to the rescue, drop privileges before starting.
   nohup perl -e "(undef, undef, \$uid, \$gid ) = getpwnam('$LOGMETRICS_USER');
     $)=\$gid;$>=\$uid;
+    close(STDOUT); close(STDERR); close(STDIN);
+    open(LOG,'|/usr/bin/logger -p daemon.info -t logmetrics_collector -i');
+    open(STDOUT, '>&LOG'); open(STDERR, '>&LOG');
     exec '$LOGMETRICS_COLLECTOR $LOGMETRICS_OPTIONS';" 2>&1 >/dev/null &
 
   PID=$!

--- a/utils/etc/init.d/logmetrics_collector
+++ b/utils/etc/init.d/logmetrics_collector
@@ -44,7 +44,7 @@ sanity_check() {
   done
 
   if [ -z "$LOGMETRICS_USER" ]; then
-    echo >&2 "error: No \$USER set"
+    echo >&2 "error: No \$LOGMETRICS_USER set"
     return 4
   fi
 }


### PR DESCRIPTION
*description*
When running in a non-interactive shell (`/etc/init.d/logmetrics_collector restart` through ssh for example), we wait on an unclosed FD indefinitely.

*solution*
Start the service after closing STDIN, STDOUT and STDERR. Then redirect STDOUT and STDERR to `logger` into facility.level `daemon.info`.

*How to test*
The following command hangs in the current version of the init script. In the new one, it doesn't.
`ssh non_root_username@my_host "sudo /etc/init.d/logmetrics_collector restart"`

*additional changes*
Change `USER` to `LOGMETRICS_USER` in error message. Thanks @gggiroux for pointing that out.

*Reviewers*
@gggiroux @hynd @mathpl  